### PR TITLE
Fix composer with drupal/core-recipe-unpack

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,10 @@
             "url": "app/composer/Plugin/VendorHardening"
         },
         {
+            "type": "path",
+            "url": "app/composer/Plugin/RecipeUnpack"
+        },
+        {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
         }
@@ -60,6 +64,7 @@
             "drupal/core-composer-scaffold": true,
             "drupal/core-project-message": true,
             "drupal/core-vendor-hardening": true,
+            "drupal/core-recipe-unpack": true,
             "phpstan/extension-installer": true,
             "php-http/discovery": true
         }


### PR DESCRIPTION
Without this I get 
```
  Problem 1
    - Root composer.json requires drupal/drupal * -> satisfiable by drupal/drupal[11.x-dev].
    - drupal/drupal 11.x-dev requires drupal/core-recipe-unpack 11.x-dev -> could not be found in any version, there may be a typo in the package name.
```